### PR TITLE
fix incompatiblites to l20n's beta 1 version

### DIFF
--- a/build/react-l20n.js
+++ b/build/react-l20n.js
@@ -72,7 +72,11 @@ var L20n = function () {
 				return this.getRaw(key, props, this.defaultLocale);
 			}
 
-			if (props === null && typeof template === "string") return this.stripFromBlacklistedChars(template);
+			// By dependency l20n@4.0.0-beta.1; ctx.format() may return other types than
+			// the object expected, so no parameters message, errors can be extracted.
+			// This will intercept the attempt by checking if only a string was passed,
+			// returning it the usual way.
+			if (!template) return undefined;else if (props === null && typeof template === "string") return this.stripFromBlacklistedChars(template);
 
 			var _ctx$format = ctx.format(template, props),
 			    _ctx$format2 = _slicedToArray(_ctx$format, 2),
@@ -85,10 +89,14 @@ var L20n = function () {
 
 			return this.stripFromBlacklistedChars(message);
 		}
+		/*
+      Since there are now two call, I made it a member function.
+   */
+
 	}, {
 		key: 'stripFromBlacklistedChars',
 		value: function stripFromBlacklistedChars(message) {
-			var blacklistedCharCodes = [8296, 8297];
+			var blacklistedCharCodes = [8296, 8297]; // What are these chars? Cannot print them
 
 			blacklistedCharCodes.forEach(function (charCode) {
 				message = message.replace(String.fromCharCode(charCode), '');

--- a/build/react-l20n.js
+++ b/build/react-l20n.js
@@ -54,7 +54,7 @@ var L20n = function () {
 	}, {
 		key: 'getRaw',
 		value: function getRaw(key, props) {
-			var locale = arguments.length <= 2 || arguments[2] === undefined ? this.defaultLocale : arguments[2];
+			var locale = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this.defaultLocale;
 
 			var ctx = this.contexts.get(locale);
 			if (!ctx) {
@@ -72,24 +72,34 @@ var L20n = function () {
 				return this.getRaw(key, props, this.defaultLocale);
 			}
 
-			var _ctx$format = ctx.format(template, props);
+			if (props === null && typeof template === "string") return this.stripFromBlacklistedChars(template);
 
-			var _ctx$format2 = _slicedToArray(_ctx$format, 2);
-
-			var message = _ctx$format2[0];
-			var errors = _ctx$format2[1];
-
+			var _ctx$format = ctx.format(template, props),
+			    _ctx$format2 = _slicedToArray(_ctx$format, 2),
+			    message = _ctx$format2[0],
+			    errors = _ctx$format2[1];
 
 			if (errors.length > 0) {
 				return undefined;
 			}
 
-			return message.replace(String.fromCharCode(8296), '').replace(String.fromCharCode(8297), '');
+			return this.stripFromBlacklistedChars(message);
+		}
+	}, {
+		key: 'stripFromBlacklistedChars',
+		value: function stripFromBlacklistedChars(message) {
+			var blacklistedCharCodes = [8296, 8297];
+
+			blacklistedCharCodes.forEach(function (charCode) {
+				message = message.replace(String.fromCharCode(charCode), '');
+			});
+
+			return message;
 		}
 	}, {
 		key: 'get',
 		value: function get(key, props) {
-			var locale = arguments.length <= 2 || arguments[2] === undefined ? this.defaultLocale : arguments[2];
+			var locale = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this.defaultLocale;
 
 			var message = this.getRaw(key, props, locale);
 			return _react2.default.createElement('span', { dangerouslySetInnerHTML: { __html: message } });
@@ -97,7 +107,7 @@ var L20n = function () {
 	}, {
 		key: 'getContext',
 		value: function getContext() {
-			var locale = arguments.length <= 0 || arguments[0] === undefined ? this.defaultLocale : arguments[0];
+			var locale = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.defaultLocale;
 
 			var ctx = this.contexts.get(locale);
 			if (!ctx) {
@@ -123,7 +133,7 @@ var L20nElement = exports.L20nElement = function (_React$Component) {
 	function L20nElement(props) {
 		_classCallCheck(this, L20nElement);
 
-		return _possibleConstructorReturn(this, Object.getPrototypeOf(L20nElement).call(this, props));
+		return _possibleConstructorReturn(this, (L20nElement.__proto__ || Object.getPrototypeOf(L20nElement)).call(this, props));
 	}
 
 	_createClass(L20nElement, [{

--- a/src/react-l20n.js
+++ b/src/react-l20n.js
@@ -50,16 +50,34 @@ class L20n
 			return this.getRaw(key, props, this.defaultLocale);
 		}
 
-		var [ message, errors ] = ctx.format(template, props);
+		// By dependency l20n@4.0.0-beta.1; ctx.format() may return other types than
+        // the object expected, so no parameters message, errors can be extracted.
+        // This will intercept the attempt by checking if only a string was passed,
+        // returning it the usual way.
+		if (props === null && typeof template === "string")
+		    return this.stripFromBlacklistedChars(template);
+
+        var [ message, errors ] = ctx.format(template, props);
 
 		if (errors.length > 0) {
 			return undefined;
 		}
 
-		return message
-			.replace(String.fromCharCode(8296), '')
-			.replace(String.fromCharCode(8297), '')			
+		return this.stripFromBlacklistedChars(message);
 	}
+	/*
+	    Since there are now two call, I made it a member function.
+	 */
+    stripFromBlacklistedChars(message)
+    {
+        const blacklistedCharCodes = [8296, 8297]; // What are these chars? Cannot print them
+
+        blacklistedCharCodes.forEach(charCode => {
+            message = message.replace(String.fromCharCode(charCode), '')
+        });
+
+        return message;
+    }
 	get(key, props, locale = this.defaultLocale)
 	{
 		var message = this.getRaw(key, props, locale)

--- a/src/react-l20n.js
+++ b/src/react-l20n.js
@@ -54,7 +54,9 @@ class L20n
         // the object expected, so no parameters message, errors can be extracted.
         // This will intercept the attempt by checking if only a string was passed,
         // returning it the usual way.
-		if (props === null && typeof template === "string")
+        if (!template)
+            return undefined;
+		else if (props === null && typeof template === "string")
 		    return this.stripFromBlacklistedChars(template);
 
         var [ message, errors ] = ctx.format(template, props);


### PR DESCRIPTION
So here was the error: 
We were using 0.0.11 with installed dependency of L20n@4.0.0-alpha.3. Since it has now changed to beta 1, there is a breaking change in the `ctx.format()` method.
It would always return its arguments in the correct object shape that react-l20n-u was expecting (`{messages,errors}`). But now, if only a string was passed and `props` was `null`, it would just return the string received.
So I tried escaping that part of the `getRaw()` method and just return the string that was found.

Hope this helps!
Best Regards