### PR TITLE
use 'prop-types' instead of React.PropTypes, which are removed in React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/marcselman/react-l20n#readme",
   "dependencies": {
     "l20n": "^4.0.0-beta.1",
+    "prop-types": "^15.6.0",
     "react": "^15.3.0"
   },
   "devDependencies": {

--- a/src/react-l20n.js
+++ b/src/react-l20n.js
@@ -4,6 +4,7 @@
 // license: MIT
 
 import React from 'react'
+import PropTypes from 'prop-types';
 import 'l20n'
 
 class L20n
@@ -133,9 +134,9 @@ export class L20nElement extends React.Component
 }
 
 L20nElement.propTypes = {
-	id: React.PropTypes.string.isRequired,
-	renderAs: React.PropTypes.string.isRequired,
-	locale: React.PropTypes.string
+	id: PropTypes.string.isRequired,
+	renderAs: PropTypes.string.isRequired,
+	locale: PropTypes.string
 };
 
 var l20n = new L20n


### PR DESCRIPTION
First of all: Thanks for sharing your work! 

React v16.0 removed ```PropTypes``` from its package as breaking change. ```'prop-types'``` should be used instead (see [React v16.0](https://reactjs.org/blog/2017/09/26/react-v16.0.html#packaging))

For people like me, who want to use React v16.0, a merge would be nice :)
